### PR TITLE
soap-hil: update image configs to work with latest phenix

### DIFF
--- a/soap-hil/image-configs/Image-ignition.yml
+++ b/soap-hil/image-configs/Image-ignition.yml
@@ -4,10 +4,13 @@ metadata:
     name: ignition
 spec:
     compress: true
-    deb_append: ' --components=main,restricted,universe,multiverse'
+    components:
+        - main
+        - restricted
+        - universe
+        - multiverse
+    no_virtuals: true
     format: qcow2
-    include_miniccc: false
-    include_protonuke: false
     mirror: http://us.archive.ubuntu.com/ubuntu/
     overlays: null
     packages:

--- a/soap-hil/image-configs/Image-ubuntu-soaptools.yml
+++ b/soap-hil/image-configs/Image-ubuntu-soaptools.yml
@@ -4,10 +4,13 @@ metadata:
     name: ubuntu-soaptools
 spec:
     compress: true
-    deb_append: " --components=main,restricted,universe,multiverse"
+    components:
+        - main
+        - restricted
+        - universe
+        - multiverse
+    no_virtuals: true
     format: qcow2
-    include_miniccc: false
-    include_protonuke: false
     mirror: http://us.archive.ubuntu.com/ubuntu/
     overlays: null
     packages:


### PR DESCRIPTION
# soap-hil: update image configs to work with latest phenix

## Description
Updating the 2 image configs included with soap-hil to work with the latest phenix image builder

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-topologies/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A